### PR TITLE
hotfix: Ensure npm run migrate works on Windows and Unix machines

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "migrate": "rm dev.db && sqlite3 dev.db < src/lib/migrations/init.sql",
+    "migrate:win": "if exist dev.db del dev.db && sqlite3 dev.db < src/lib/migrations/init.sql",
+    "migrate:unix": "rm -f dev.db && sqlite3 dev.db < src/lib/migrations/init.sql",
+    "migrate": "npm run migrate:win || npm run migrate:unix",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"


### PR DESCRIPTION
This PR updates the migrate script in package.json to ensure it works on Windows machines. Previously, npm run migrate was not running on my Windows system due to the use of the Unix rm command. Now, the script first attempts to run the Windows-specific migration command. If it fails (on Unix machines), it falls back to the Unix-compatible command.

Updated package.json:
Runs the Windows migration command first.
If it fails, it falls back to the Unix migration command.
Ensured cross-platform compatibility for npm run migrate.

Testing
Verified on Windows
Need testing on Unix machines!!

How to Test:
Run npm run migrate on a Unix/Linux/macOS machine.

Feel free to test it out on other Windows machines as well.